### PR TITLE
Replace manual try/finally with `using` declarations in TS parser

### DIFF
--- a/packages/babel-parser/src/plugins/typescript/index.ts
+++ b/packages/babel-parser/src/plugins/typescript/index.ts
@@ -1771,16 +1771,6 @@ export default (superClass: ClassWithMixin<typeof Parser, IJSXParserMixin>) =>
       return this.finishNode(node, "TSTypeAliasDeclaration");
     }
 
-    tsInNoContext<T>(cb: () => T): T {
-      const oldContext = this.state.context;
-      this.state.context = [oldContext[0]];
-      try {
-        return cb();
-      } finally {
-        this.state.context = oldContext;
-      }
-    }
-
     tsInDisallowConditionalTypesContext<T>(cb: () => T): T {
       const oldInDisallowConditionalTypesContext =
         this.state.inDisallowConditionalTypesContext;
@@ -2226,15 +2216,15 @@ export default (superClass: ClassWithMixin<typeof Parser, IJSXParserMixin>) =>
     tsParseTypeArguments(): N.TsTypeParameterInstantiation {
       const node = this.startNode<N.TsTypeParameterInstantiation>();
       {
-        using _ = this.withState("inType", true);
+        using _1 = this.withState("inType", true);
         // Temporarily remove a JSX parsing context, which makes us scan different tokens.
-        this.tsInNoContext(() => {
-          this.expect(tt.lt);
-          node.params = this.tsParseDelimitedList(
-            "TypeParametersOrArguments",
-            this.tsParseType.bind(this),
-          );
-        });
+        using _2 = this.withState("context", this.state.context.slice(0, 1));
+
+        this.expect(tt.lt);
+        node.params = this.tsParseDelimitedList(
+          "TypeParametersOrArguments",
+          this.tsParseType.bind(this),
+        );
       }
       if (node.params.length === 0) {
         this.raise(TSErrors.EmptyTypeArguments, node);

--- a/packages/babel-parser/src/plugins/typescript/index.ts
+++ b/packages/babel-parser/src/plugins/typescript/index.ts
@@ -3822,13 +3822,8 @@ export default (superClass: ClassWithMixin<typeof Parser, IJSXParserMixin>) =>
       isStatement: boolean,
       optionalId?: boolean,
     ): T {
-      const oldInAbstractClass = this.state.inAbstractClass;
-      this.state.inAbstractClass = !!(node as any).abstract;
-      try {
-        return super.parseClass(node, isStatement, optionalId);
-      } finally {
-        this.state.inAbstractClass = oldInAbstractClass;
-      }
+      using _ = this.withState("inAbstractClass", !!(node as any).abstract);
+      return super.parseClass(node, isStatement, optionalId);
     }
 
     tsParseAbstractDeclaration(

--- a/packages/babel-parser/src/tokenizer/state.ts
+++ b/packages/babel-parser/src/tokenizer/state.ts
@@ -146,11 +146,11 @@ export default class State {
       this.flags &= ~StateFlags.inAbstractClass;
     }
   }
-  get inDisallowConditionalTypesContext(): boolean {
-    return (this.flags & StateFlags.inDisallowConditionalTypesContext) > 0;
+  get allowConditionalTypes(): boolean {
+    return !(this.flags & StateFlags.inDisallowConditionalTypesContext);
   }
-  set inDisallowConditionalTypesContext(value: boolean) {
-    if (value) {
+  set allowConditionalTypes(value: boolean) {
+    if (!value) {
       this.flags |= StateFlags.inDisallowConditionalTypesContext;
     } else {
       this.flags &= ~StateFlags.inDisallowConditionalTypesContext;

--- a/scripts/integration-tests/e2e-babel-old-version.sh
+++ b/scripts/integration-tests/e2e-babel-old-version.sh
@@ -24,6 +24,10 @@ startLocalRegistry "$PWD"/scripts/integration-tests/verdaccio-config.yml
 
 node "$PWD"/scripts/integration-tests/utils/bump-babel-dependencies.js
 
+# Go back to a commit that can be compiled using Babel 7.0.0. Newer commits rely
+# on `using` declarations, that are only supported since Babel 7.22.0
+git checkout 218faee4351345415b40b23a9e0102f628d45108
+
 node -e "
   var pkg = require('./package.json');
   pkg.devDependencies['@babel/core'] = '7.0.0';


### PR DESCRIPTION
Better viewed with whitespace diff disabled, as there are a lot of indentation changes: https://github.com/nicolo-ribaudo/babel/pull/10/files?w=1